### PR TITLE
Implementation of model_generator

### DIFF
--- a/src/model_generator.py
+++ b/src/model_generator.py
@@ -1,15 +1,46 @@
-from typing import Dict, Type, Optional, Any
-from datetime import date, time, datetime
+from datetime import datetime
 from decimal import Decimal
+from typing import Dict, Optional, Type
 
 from dlt.common.schema import Schema, TTableSchema
-from dlt.common.schema.typing import TDataType
 from pydantic import BaseModel, create_model
+from pydantic.fields import FieldInfo
 
 
 def _generate_model(name: str, schema: TTableSchema) -> Type[BaseModel]:
-    # TODO: IMPLEMENT ME
-    return BaseModel
+    columns = schema["columns"]
+    # If the name of the column in the schema might shadow an
+    # attribute for the base model, we get an error. So we need to
+    # check names that we should use an alias
+    protected_names = ["schema"]
+    column_type_map = {
+        "bool": bool,
+        "timestamp": datetime,
+        "bigint": int,
+        "text": str,
+        "decimal": Decimal,
+        "complex": Dict,
+    }
+
+    fields = {}
+
+    for column, column_spec in columns.items():
+        required = not column_spec["nullable"]
+
+        field_name = column if column not in protected_names else f"_{column}"
+        data_type = column_type_map.get(str(column_spec["data_type"]))
+
+        assert data_type is not None
+
+        # I'd rather find a more proper way to do this check, but
+        # apparently create_model is not meant to be used for more
+        # complex field definitions
+        if not required:
+            data_type = Optional[data_type]  # type: ignore
+
+        fields[field_name] = (data_type, FieldInfo(alias=column))
+
+    return create_model(name, **fields)  # type: ignore
 
 
 def generate_models(schema: Schema) -> Dict[str, Type[BaseModel]]:

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -1,12 +1,10 @@
 import json
-import pytest
 from decimal import Decimal
 
+import pytest
 from dlt.common.schema import Schema
-
-from src.model_generator import generate_models
-
 from pydantic import ValidationError
+from src.model_generator import generate_models
 
 # this is a dict that should pass validation of the "my_table" model
 VALID_DICT = {
@@ -46,3 +44,15 @@ def test_model_generator() -> None:
     # missing required field will raise
     with pytest.raises(ValidationError):
         table_model.model_validate({"foo": "Hello"})
+
+
+def test_required_fields() -> None:
+    # A test using a schema with nullable fields to check if the
+    # pydantic model is created with an "Optional" attribute
+    pass
+
+
+def test_aliased_fields() -> None:
+    # A test using a schema with field having a conflicting name with
+    # pydantic fields should still be created without problem
+    pass


### PR DESCRIPTION
Below is the implementation of the `model_generator` function. The function pass the tests but registers some warnings regarding the schema fields starting with underscore. Example:

```
RuntimeWarning: fields may not start with an underscore, ignoring "_dlt_id"
    warnings.warn(f'fields may not start with an underscore, ignoring "{f_name}"', RuntimeWarning)
```

I considered a method that would rename the field name, but this seems beyond the scope of the task. It would be interesting to discuss a strategy to include these fields in the final model, perhaps by transforming transforming fields starting with underscore into a prefixed namespace.

My implementation also has some warnings from mypy on two lines. The first is because I am redefining the type that is going to be used, the second is not exactly clear to me what is "wrong" with the way that I am calling `create_model`. Both of these errors are ignored, but I might investigate a bit further for a more correct approach.

 Additional tasks:

 - Field annotations from dlt schemas such as primary_key or unique could be turned into validator functions from the model being dynamically generated model. The `create_model` function takes the `__validators__` keyword argument, which could then carry the implementation of the checking for uniqueness of the attribute in a given collection.
 
  - A simple schema contract that needs to fail validation if the object has unspecified attributes could be handled via the "extra.DENY" parameter.
  
   - Precision information for decimal fields could be handled by field validators. If we simply want to ensure that any incoming object is recorded with a desired precision, We can define a validator function that calls Decimal.quantize.